### PR TITLE
Automatically trigger Dice So Nice when rolling if it's installed

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -313,6 +313,7 @@ export class CthulhuDarkActorSheet extends ActorSheet {
                   dieColor: CONFIG.CTHULHUDARK.BaseColor,
                   isRisk: false,
                   rollVal: hdRoll.result,
+                  roll: hdRoll,
                 });
               }
 
@@ -322,6 +323,7 @@ export class CthulhuDarkActorSheet extends ActorSheet {
                   dieColor: CONFIG.CTHULHUDARK.BaseColor,
                   isRisk: false,
                   rollVal: odRoll.result,
+                  roll: odRoll,
                 });
               }
 
@@ -331,6 +333,7 @@ export class CthulhuDarkActorSheet extends ActorSheet {
                   dieColor: CONFIG.CTHULHUDARK.RiskColor,
                   isRisk: true,
                   rollVal: idRoll.result,
+                  roll: idRoll,
                 });
               }
 
@@ -375,10 +378,32 @@ export class CthulhuDarkActorSheet extends ActorSheet {
 
               ChatMessage.create({
                 user: user,
+                type: CONST.CHAT_MESSAGE_TYPES.ROLL,
+                rolls: dice.map((die) => {
+                  // If "Dice So Nice!" is installed, this configuration will trigger a visual
+                  // dice roll with appropriate standard and insight colored dice
+                  if (game.dice3d) {
+                    if (die.isRisk) {
+                      die.roll.dice[0].options.appearance = {
+                        colorset: "custom",
+                        foreground: "black",
+                        background: CONFIG.CTHULHUDARK.RiskColor,
+                      };
+                    } else {
+                      die.roll.dice[0].options.appearance = {
+                        colorset: "custom",
+                        foreground: "black",
+                        background: CONFIG.CTHULHUDARK.BaseColor,
+                      };
+                    }
+                  }
+
+                  return die.roll;
+                }),
                 speaker: speaker,
                 rollMode: rollMode,
                 content: chatContentMessage,
-                flags: { cthulhudark: { chatID: "cthulhudark" }}
+                flags: { cthulhudark: { chatID: "cthulhudark" }},
               });
 
               // ----
@@ -470,9 +495,19 @@ export class CthulhuDarkActorSheet extends ActorSheet {
     const speaker = ChatMessage.getSpeaker({ actor: this.actor });
     const rollMode = game.settings.get("core", "rollMode");
 
+    // If "Dice So Nice!" is installed, this data will cause it to roll a
+    // visual die with the insight theme colors
+    insightRoll.dice[0].options.appearance = {
+      colorset: "custom",
+      foreground: "black",
+      background: CONFIG.CTHULHUDARK.RiskColor,
+    }
+
     ChatMessage.create({
       user: user,
       speaker: speaker,
+      type: CONST.CHAT_MESSAGE_TYPES.ROLL,
+      rolls: [insightRoll],
       rollMode: rollMode,
       content: chatContentMessage,
       flags: { cthulhudark: { chatID: "cthulhudark" }}
@@ -503,9 +538,19 @@ export class CthulhuDarkActorSheet extends ActorSheet {
     const speaker = ChatMessage.getSpeaker({ actor: this.actor });
     const rollMode = game.settings.get("core", "rollMode");
 
+    // If "Dice So Nice!" is installed, this data will cause it to roll a
+    // visual die with the insight theme colors
+    failureRoll.dice[0].options.appearance = {
+      colorset: "custom",
+      foreground: "black",
+      background: CONFIG.CTHULHUDARK.BaseColor,
+    }
+
     ChatMessage.create({
       user: user,
       speaker: speaker,
+      type: CONST.CHAT_MESSAGE_TYPES.ROLL,
+      rolls: [failureRoll],
       rollMode: rollMode,
       content: chatContentMessage,
       flags: { cthulhudark: { chatID: "cthulhudark" }}


### PR DESCRIPTION
# Description

This adds automatic integration with the Dice So Nice module if it's installed. I tried to do so in a way that used as many standard foundry dice rolling fields as possible and only referenced Dice So Nice specifics when absolutely necessary. For example, the `rolls` field is added so Dice So Nice can automatically get the roll information from the chat message, without any specific code to call out to that module.

It also sets the insight die's appearance so it's the same color that the insight die is configured to use in the module, for visual consistency.

# Testing

I tested all permutations of each type of roll with Dice So Nice installed and then uninstalled it and tested the existing functionality to ensure no regressions.

Tested in FoundryVTT 11 and 12.